### PR TITLE
Update BlockChangeArray.java

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/BlockChangeArray.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/BlockChangeArray.java
@@ -176,7 +176,7 @@ public class BlockChangeArray {
 		}
 		
 		private int getValue(int rightShift, int updateMask) {
-			return (data[index] & updateMask) >> rightShift;
+			return (data[index] & updateMask) >>> rightShift;
 		}
 	}
 	


### PR DESCRIPTION
That fixes getting relative X from change array. X is stored in 4 msb, but >> operator doesn't move the sign extension bit (so it actually moves 3 bits out of 4 for x which results in invalid X).