### PR TITLE
Add ability to read/update contents of a PacketCustomPayload

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayClientCustomPayload.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayClientCustomPayload.java
@@ -21,6 +21,9 @@ package com.comphenix.packetwrapper;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 public class WrapperPlayClientCustomPayload extends AbstractPacket {
     public static final PacketType TYPE = PacketType.Play.Client.CUSTOM_PAYLOAD;
     
@@ -51,6 +54,40 @@ public class WrapperPlayClientCustomPayload extends AbstractPacket {
         handle.getStrings().write(0, value);
     }
     
-    // Cannot find type for b
+    /**
+     * Retrieve payload contents as a raw Netty buffer
+     * 
+     * @return Payload contents as a Netty buffer
+     */
+    public ByteBuf getContentsBuffer() {
+        return (ByteBuf) handle.getModifier().withType(ByteBuf.class).read(0);
+    }
+    
+    /**
+     * Retrieve payload contents
+     * 
+     * @return Payload contents as a byte array
+     */
+    public byte[] getContents() {
+        return getContentsBuffer().array();
+    }
+    
+    /**
+     * Update payload contents with a Netty buffer
+     * 
+     * @param content - new payload content
+     */
+    public void setContentsBuffer(ByteBuf contents) {
+        handle.getModifier().withType(ByteBuf.class).write(0, contents);
+    }
+    
+    /**
+     * Update payload contents with a byte array
+     * 
+     * @param content - new payload content
+     */
+    public void setContents(byte[] content) {
+        setContentsBuffer(Unpooled.copiedBuffer(content));
+    }
 }
 

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerCustomPayload.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerCustomPayload.java
@@ -21,6 +21,9 @@ package com.comphenix.packetwrapper;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 public class WrapperPlayServerCustomPayload extends AbstractPacket {
     public static final PacketType TYPE = PacketType.Play.Server.CUSTOM_PAYLOAD;
     
@@ -51,6 +54,40 @@ public class WrapperPlayServerCustomPayload extends AbstractPacket {
         handle.getStrings().write(0, value);
     }
     
-    // Cannot find type for b
+    /**
+     * Retrieve payload contents as a raw Netty buffer
+     * 
+     * @return Payload contents as a Netty buffer
+     */
+    public ByteBuf getContentsBuffer() {
+        return (ByteBuf) handle.getModifier().withType(ByteBuf.class).read(0);
+    }
+    
+    /**
+     * Retrieve payload contents
+     * 
+     * @return Payload contents as a byte array
+     */
+    public byte[] getContents() {
+        return getContentsBuffer().array();
+    }
+    
+    /**
+     * Update payload contents with a Netty buffer
+     * 
+     * @param content - new payload content
+     */
+    public void setContentsBuffer(ByteBuf contents) {
+        handle.getModifier().withType(ByteBuf.class).write(0, contents);
+    }
+    
+    /**
+     * Update payload contents with a byte array
+     * 
+     * @param content - new payload content
+     */
+    public void setContents(byte[] content) {
+        setContentsBuffer(Unpooled.copiedBuffer(content));
+    }
 }
 


### PR DESCRIPTION
ProtocolLib has no public accessor for a ByteBuf fields, but it is easy to create your own. Tested on 1.8.4 Spigot with my own reading code - ByteBuf's from this field can be converted into more usual byte arrays with `.array()` method and converted back with `Unpooled.copiedBuffer(byte[])` method. So attached code shoud work, but I did not tested it directly.