### PR TITLE
Clean up AbstractPacket

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
@@ -83,24 +83,6 @@ public abstract class AbstractPacket {
 	 * Simulate receiving the current packet from the given sender.
 	 * 
 	 * @param sender - the sender.
-	 * @throws RuntimeException If the packet cannot be received.
-	 * @deprecated Misspelled. recieve to receive
-	 * @see #receivePacket(Player)
-	 */
-	@Deprecated
-	public void recievePacket(Player sender) {
-		try {
-			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
-					getHandle());
-		} catch (Exception e) {
-			throw new RuntimeException("Cannot recieve packet.", e);
-		}
-	}
-
-	/**
-	 * Simulate receiving the current packet from the given sender.
-	 * 
-	 * @param sender - the sender.
 	 * @throws RuntimeException if the packet cannot be received.
 	 */
 	public void receivePacket(Player sender) {

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
@@ -62,8 +62,7 @@ public abstract class AbstractPacket {
 	 */
 	public void sendPacket(Player receiver) {
 		try {
-			ProtocolLibrary.getProtocolManager().sendServerPacket(receiver,
-					getHandle());
+			ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, getHandle());
 		} catch (InvocationTargetException e) {
 			throw new RuntimeException("Cannot send packet.", e);
 		}
@@ -84,8 +83,7 @@ public abstract class AbstractPacket {
 	 */
 	public void receivePacket(Player sender) {
 		try {
-			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
-					getHandle());
+			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender, getHandle());
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot receive packet.", e);
 		}

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
@@ -2,17 +2,17 @@
  * PacketWrapper - ProtocolLib wrappers for Minecraft packets
  * Copyright (C) dmulloy2 <http://dmulloy2.net>
  * Copyright (C) Kristian S. Strangeland
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,63 +29,63 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.google.common.base.Objects;
 
 public abstract class AbstractPacket {
-	// The packet we will be modifying
-	protected PacketContainer handle;
+    // The packet we will be modifying
+    protected PacketContainer handle;
 
-	/**
-	 * Constructs a new strongly typed wrapper for the given packet.
-	 * 
-	 * @param handle - handle to the raw packet data.
-	 * @param type - the packet type.
-	 */
-	protected AbstractPacket(PacketContainer handle, PacketType type) {
-		// Make sure we're given a valid packet
-		Preconditions.checkNotNull(handle, "Packet handle cannot be NULL.");
+    /**
+     * Constructs a new strongly typed wrapper for the given packet.
+     *
+     * @param handle - handle to the raw packet data.
+     * @param type - the packet type.
+     */
+    protected AbstractPacket(PacketContainer handle, PacketType type) {
+        // Make sure we're given a valid packet
+        Preconditions.checkNotNull(handle, "Packet handle cannot be NULL.");
         Preconditions.checkArgument(Objects.equal(handle.getType(), type), handle.getHandle() + " is not a packet of type " + type);
-		this.handle = handle;
-	}
+        this.handle = handle;
+    }
 
-	/**
-	 * Retrieve a handle to the raw packet data.
-	 * 
-	 * @return Raw packet data.
-	 */
-	public PacketContainer getHandle() {
-		return handle;
-	}
+    /**
+     * Retrieve a handle to the raw packet data.
+     *
+     * @return Raw packet data.
+     */
+    public PacketContainer getHandle() {
+        return handle;
+    }
 
-	/**
-	 * Send the current packet to the given receiver.
-	 * 
-	 * @param receiver - the receiver.
-	 * @throws RuntimeException If the packet cannot be sent.
-	 */
-	public void sendPacket(Player receiver) {
-		try {
-			ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, getHandle());
-		} catch (InvocationTargetException e) {
-			throw new RuntimeException("Cannot send packet.", e);
-		}
-	}
+    /**
+     * Send the current packet to the given receiver.
+     *
+     * @param receiver - the receiver.
+     * @throws RuntimeException If the packet cannot be sent.
+     */
+    public void sendPacket(Player receiver) {
+        try {
+            ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, getHandle());
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException("Cannot send packet.", e);
+        }
+    }
 
-	/**
-	 * Send the current packet to all online players.
-	 */
-	public void broadcastPacket() {
-		ProtocolLibrary.getProtocolManager().broadcastServerPacket(getHandle());
-	}
+    /**
+     * Send the current packet to all online players.
+     */
+    public void broadcastPacket() {
+        ProtocolLibrary.getProtocolManager().broadcastServerPacket(getHandle());
+    }
 
-	/**
-	 * Simulate receiving the current packet from the given sender.
-	 * 
-	 * @param sender - the sender.
-	 * @throws RuntimeException if the packet cannot be received.
-	 */
-	public void receivePacket(Player sender) {
-		try {
-			ProtocolLibrary.getProtocolManager().recieveClientPacket(sender, getHandle());
-		} catch (Exception e) {
-			throw new RuntimeException("Cannot receive packet.", e);
-		}
-	}
+    /**
+     * Simulate receiving the current packet from the given sender.
+     *
+     * @param sender - the sender.
+     * @throws RuntimeException if the packet cannot be received.
+     */
+    public void receivePacket(Player sender) {
+        try {
+            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender, getHandle());
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot receive packet.", e);
+        }
+    }
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/AbstractPacket.java
@@ -20,6 +20,7 @@ package com.comphenix.packetwrapper;
 
 import java.lang.reflect.InvocationTargetException;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 
 import com.comphenix.protocol.PacketType;
@@ -39,12 +40,8 @@ public abstract class AbstractPacket {
 	 */
 	protected AbstractPacket(PacketContainer handle, PacketType type) {
 		// Make sure we're given a valid packet
-		if (handle == null)
-			throw new IllegalArgumentException("Packet handle cannot be NULL.");
-		if (!Objects.equal(handle.getType(), type))
-			throw new IllegalArgumentException(handle.getHandle()
-					+ " is not a packet of type " + type);
-
+		Preconditions.checkNotNull(handle, "Packet handle cannot be NULL.");
+        Preconditions.checkArgument(Objects.equal(handle.getType(), type), handle.getHandle() + " is not a packet of type " + type);
 		this.handle = handle;
 	}
 


### PR DESCRIPTION
The "recievePacket" method has been deprecated for almost a year now and the replacement method is directly below the misspelled one. All plugins should have updated by now.

Instead of throwing the exceptions manually the Preconditions class is helping out.
Please note that I throw a NullPointerException if the packet handle is null and no longer an IllegalArgumentException. If this is not desired the line can be changed to 
`Preconditions.checkArgument(handle != null,"Packet handle cannot be NULL.");`