### PR TITLE
Fix WrapperPlayServerExplosion read & write

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
@@ -145,27 +145,27 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	}
 
 	public float getPlayerVelocityX() {
-		return handle.getFloat().read(0);
-	}
-
-	public void setPlayerVelocityX(float value) {
-		handle.getFloat().write(0, value);
-	}
-
-	public float getPlayerVelocityY() {
 		return handle.getFloat().read(1);
 	}
 
-	public void setPlayerVelocityY(float value) {
+	public void setPlayerVelocityX(float value) {
 		handle.getFloat().write(1, value);
 	}
 
-	public float getPlayerVelocityZ() {
+	public float getPlayerVelocityY() {
 		return handle.getFloat().read(2);
 	}
 
-	public void setPlayerVelocityZ(float value) {
+	public void setPlayerVelocityY(float value) {
 		handle.getFloat().write(2, value);
+	}
+
+	public float getPlayerVelocityZ() {
+		return handle.getFloat().read(3);
+	}
+
+	public void setPlayerVelocityZ(float value) {
+		handle.getFloat().write(3, value);
 	}
 
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
@@ -41,8 +41,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @return The current X
 	 */
-	public double getX() {
-		return handle.getDoubles().read(0);
+	public float getX() {
+		return handle.getFloat().read(0);
 	}
 
 	/**
@@ -50,8 +50,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @param value - new value.
 	 */
-	public void setX(double value) {
-		handle.getDoubles().write(0, value);
+	public void setX(float value) {
+		handle.getFloat().write(0, value);
 	}
 
 	/**
@@ -59,8 +59,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @return The current Y
 	 */
-	public double getY() {
-		return handle.getDoubles().read(1);
+	public float getY() {
+		return handle.getFloat().read(1);
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setY(double value) {
-		handle.getDoubles().write(1, value);
+		handle.getFloat().write(1, value);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @return The current Z
 	 */
 	public double getZ() {
-		return handle.getDoubles().read(2);
+		return handle.getFloat().read(2);
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setZ(double value) {
-		handle.getDoubles().write(2, value);
+		handle.getFloat().write(2, value);
 	}
 
 	/**
@@ -98,7 +98,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @return The current Radius
 	 */
 	public float getRadius() {
-		return handle.getFloat().read(0);
+		return handle.getFloat().read(3);
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setRadius(float value) {
-		handle.getFloat().write(0, value);
+		handle.getFloat().write(3, value);
 	}
 
 	/**
@@ -145,27 +145,27 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	}
 
 	public float getPlayerVelocityX() {
-		return handle.getFloat().read(1);
+		return handle.getFloat().read(4);
 	}
 
 	public void setPlayerVelocityX(float value) {
-		handle.getFloat().write(1, value);
+		handle.getFloat().write(4, value);
 	}
 
 	public float getPlayerVelocityY() {
-		return handle.getFloat().read(2);
+		return handle.getFloat().read(5);
 	}
 
 	public void setPlayerVelocityY(float value) {
-		handle.getFloat().write(2, value);
+		handle.getFloat().write(5, value);
 	}
 
 	public float getPlayerVelocityZ() {
-		return handle.getFloat().read(3);
+		return handle.getFloat().read(6);
 	}
 
 	public void setPlayerVelocityZ(float value) {
-		handle.getFloat().write(3, value);
+		handle.getFloat().write(6, value);
 	}
 
 }

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerExplosion.java
@@ -41,8 +41,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @return The current X
 	 */
-	public float getX() {
-		return handle.getFloat().read(0);
+	public double getX() {
+		return handle.getDoubles().read(0);
 	}
 
 	/**
@@ -50,8 +50,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @param value - new value.
 	 */
-	public void setX(float value) {
-		handle.getFloat().write(0, value);
+	public void setX(double value) {
+		handle.getDoubles().write(0, value);
 	}
 
 	/**
@@ -59,8 +59,8 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * 
 	 * @return The current Y
 	 */
-	public float getY() {
-		return handle.getFloat().read(1);
+	public double getY() {
+		return handle.getDoubles().read(1);
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setY(double value) {
-		handle.getFloat().write(1, value);
+		handle.getDoubles().write(1, value);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @return The current Z
 	 */
 	public double getZ() {
-		return handle.getFloat().read(2);
+		return handle.getDoubles().read(2);
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setZ(double value) {
-		handle.getFloat().write(2, value);
+		handle.getDoubles().write(2, value);
 	}
 
 	/**
@@ -98,7 +98,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @return The current Radius
 	 */
 	public float getRadius() {
-		return handle.getFloat().read(3);
+		return handle.getFloat().read(0);
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setRadius(float value) {
-		handle.getFloat().write(3, value);
+		handle.getFloat().write(0, value);
 	}
 
 	/**
@@ -145,27 +145,27 @@ public class WrapperPlayServerExplosion extends AbstractPacket {
 	}
 
 	public float getPlayerVelocityX() {
-		return handle.getFloat().read(4);
+		return handle.getFloat().read(1);
 	}
 
 	public void setPlayerVelocityX(float value) {
-		handle.getFloat().write(4, value);
+		handle.getFloat().write(1, value);
 	}
 
 	public float getPlayerVelocityY() {
-		return handle.getFloat().read(5);
+		return handle.getFloat().read(2);
 	}
 
 	public void setPlayerVelocityY(float value) {
-		handle.getFloat().write(5, value);
+		handle.getFloat().write(2, value);
 	}
 
 	public float getPlayerVelocityZ() {
-		return handle.getFloat().read(6);
+		return handle.getFloat().read(3);
 	}
 
 	public void setPlayerVelocityZ(float value) {
-		handle.getFloat().write(6, value);
+		handle.getFloat().write(3, value);
 	}
 
 }


### PR DESCRIPTION
Hey, this bug is just 4 years and 5 months old ;)

https://github.com/dmulloy2/PacketWrapper/commit/6da31d1c9038efd1376ab4658234f42947228320#diff-3dd2f80044d9a5b08cec864edd2f7381

Some packetwrapper classes seem to be really unused...

Edit: Apparantly a part of this bug is even older and existed since the beginning of this repository lol (1.7.2 was released after 13w41b):
https://github.com/dmulloy2/PacketWrapper/commit/8c9273f504ad2fec964cf97b100a66678dc0e021#diff-9a137870ac0a97f240d12e94c59da5b3

Edit 2: Oops, seems I have to test this a little more, its transported as float, but the class still holds it as double.