### PR TITLE
Use the latest version of ProtocolLib

### DIFF
--- a/PacketWrapper/pom.xml
+++ b/PacketWrapper/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.5.0-SNAPSHOT</version>
+      <version>4.5.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/PacketWrapper/pom.xml
+++ b/PacketWrapper/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.4.0</version>
+      <version>4.5.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/PacketWrapper/pom.xml
+++ b/PacketWrapper/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.4.0-SNAPSHOT</version>
+      <version>4.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use latest non-snapshot version of ProtocolLib
This fixes build issues due to unfound dependency (4.4.0-SNAPSHOT seems to missing in at repo.dmulloy2.net)
Data taken from: http://repo.dmulloy2.net/nexus/service/rest/repository/browse/public/com/comphenix/protocol/ProtocolLib/