### PR TITLE
gamestate reason

### DIFF
--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerGameStateChange.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerGameStateChange.java
@@ -40,7 +40,7 @@ public class WrapperPlayServerGameStateChange extends AbstractPacket {
 	 * @return The current Reason
 	 */
 	public int getReason() {
-		return handle.getIntegers().read(0);
+		return handle.getGameStateIDs().read(0);
 	}
 
 	/**
@@ -49,7 +49,7 @@ public class WrapperPlayServerGameStateChange extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setReason(int value) {
-		handle.getIntegers().write(0, value);
+		handle.getGameStateIDs().write(0, value);
 	}
 
 	/**


### PR DESCRIPTION
Access game state reason via getGameStateIDs(), as described in [ProtocolLib/issues/1279](https://github.com/dmulloy2/ProtocolLib/issues/1279).