### PR TITLE
Fixed AttachEntity using wrong indexes

### DIFF
--- a/PacketWrapper/pom.xml
+++ b/PacketWrapper/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.5.1-SNAPSHOT</version>
+      <version>4.7.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -76,6 +76,17 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-gpg-plugin</artifactId>
+      <version>3.0.1</version>
+      <type>maven-plugin</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-source-plugin</artifactId>
+      <version>3.2.1</version>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -92,7 +103,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -105,7 +116,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -137,7 +148,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>

--- a/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerAttachEntity.java
+++ b/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayServerAttachEntity.java
@@ -45,7 +45,7 @@ public class WrapperPlayServerAttachEntity extends AbstractPacket {
 	 * @return The current Entity ID
 	 */
 	public int getEntityID() {
-		return handle.getIntegers().read(0);
+		return handle.getIntegers().read(1);
 	}
 
 	/**
@@ -54,7 +54,7 @@ public class WrapperPlayServerAttachEntity extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setEntityID(int value) {
-		handle.getIntegers().write(0, value);
+		handle.getIntegers().write(1, value);
 	}
 
 	/**
@@ -85,7 +85,7 @@ public class WrapperPlayServerAttachEntity extends AbstractPacket {
 	 * @return The current Vehicle ID
 	 */
 	public int getVehicleId() {
-		return handle.getIntegers().read(1);
+		return handle.getIntegers().read(2);
 	}
 
 	/**
@@ -94,6 +94,6 @@ public class WrapperPlayServerAttachEntity extends AbstractPacket {
 	 * @param value - new value.
 	 */
 	public void setVehicleId(int value) {
-		handle.getIntegers().write(1, value);
+		handle.getIntegers().write(2, value);
 	}
 }


### PR DESCRIPTION
The WrapperPlayServerAttachEntity class has been accessing the vehicle and entity id in the wrong indexes